### PR TITLE
:bug: Bugfix: scope databricks connection to datasource instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 1.1.5
+## 1.1.6
+
+- Bugfix: Correctly scope Databricks Connection to Datasource instance, in order to support multiple Databricks Datasources
+
+---
+
+### 1.1.5
 
 - Upgrade databricks-sql-go dependency to v1.4.0
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mullerpeter-databricks-datasource",
   "private": true,
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Databricks SQL Connector",
   "scripts": {
     "build": "grafana-toolkit plugin:build",


### PR DESCRIPTION
Correctly scope Databricks Connection to Datasource instance, in order to support multiple Databricks Datasources

Fixes #25 