### PR TITLE
:bug: Fix: reintroduce connection refresh on invalid session handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 1.2.2
+## 1.2.3
+
+- Bugfix: Reintroduce Connection Refresh on Invalid SessionHandle error
+
+---
+
+### 1.2.2
 
 - Bugfix: (Auto complete suggestions) Check if current schema & current catalog exist before fetching tables/schemas/columns
 - Chore: Upgrade go & npm dependencies to latest versions

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mullerpeter-databricks-datasource",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Databricks SQL Connector",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Reintroduce the connection refresh logic removed in #28 to refresh the databricks session on Invalid SessionHandle Errors.

Fixes #60
Fixes #61 
Fixes #27 
