### PR TITLE
:bug: Fix: add support for milliseconds in time window interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 1.2.4
+## 1.2.5
+
+- Fix: Add support for milliseconds in time window interval
+
+---
+
+### 1.2.4
 
 - Chore: Upgrade go & npm dependencies to latest versions
 - Refactor: SetConnMaxIdleTime to 6 hours on Databricks Connection Refresh

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mullerpeter-databricks-datasource",
   "private": true,
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Databricks SQL Connector",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -14,6 +14,7 @@ func getIntervalString(duration time.Duration) string {
 	hours := int(math.Floor(duration.Hours()))
 	minutes := int(math.Floor(duration.Minutes()))
 	seconds := int(math.Floor(duration.Seconds()))
+	milliseconds := int(duration.Milliseconds())
 
 	returnString := ""
 
@@ -32,6 +33,12 @@ func getIntervalString(duration time.Duration) string {
 	remainingSeconds := seconds - (minutes * 60)
 	if remainingSeconds > 0 {
 		returnString = fmt.Sprintf("%s%s%d SECONDS", returnString, deliminator, remainingSeconds)
+		deliminator = " "
+	}
+
+	remainingMilliseconds := milliseconds - (seconds * 1000)
+	if remainingMilliseconds > 0 {
+		returnString = fmt.Sprintf("%s%s%d MILLISECONDS", returnString, deliminator, remainingMilliseconds)
 		deliminator = " "
 	}
 


### PR DESCRIPTION
- Adds support for milliseconds in interval when using `$__timeWindow(timestamp)` macro

Fixes #77 