### PR TITLE
Feat: Add external credentials support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ Available configuration fields are as follows:
 | Server Hostname       | Databricks Server Hostname (without http). i.e. `XXX.cloud.databricks.com`                                   |
 | Server Port           | Databricks Server Port (default `443`)                                                                       |
 | HTTP Path             | HTTP Path value for the existing cluster or SQL warehouse. i.e. `sql/1.0/endpoints/XXX`                      |
-| Authentication Method | PAT (Personal Access Token) or M2M (Machine to Machine) OAuth Authentication                                 |
-| Client ID             | Databricks Service Principal Client ID. (only if M2M OAuth is chosen as Auth Method)                         |
-| Client Secret         | Databricks Service Principal Client Secret. (only if M2M OAuth is chosen as Auth Method)                     |
+| Authentication Method | PAT (Personal Access Token), M2M (Machine to Machine) OAuth or OAuth2 Client Credentials Authentication      |
+| Client ID             | Databricks Service Principal Client ID. (only if OAuth / OAuth2 is chosen as Auth Method)                    |
+| Client Secret         | Databricks Service Principal Client Secret. (only if OAuth / OAuth2 is chosen as Auth Method)                |
 | Access Token          | Personal Access Token for Databricks. (only if PAT is chosen as Auth Method)                                 |
+| OAuth2 Token Endpoint | URL of OAuth2 endpoint (only if OAuth2 Client Credentials Authentication is chosen as Auth Method)           |
 | Code Auto Completion  | If enabled the SQL editor will fetch catalogs/schemas/tables/columns from Databricks to provide suggestions. |
 
 ### Supported Macros

--- a/pkg/integrations/oauth2_client_credentials.go
+++ b/pkg/integrations/oauth2_client_credentials.go
@@ -1,0 +1,71 @@
+package integrations
+
+import (
+	"context"
+	"github.com/databricks/databricks-sql-go/auth"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type oauth2ClientCredentials struct {
+	clientID     string
+	clientSecret string
+	tokenUrl     string
+	tokenSource  oauth2.TokenSource
+	mx           sync.Mutex
+}
+
+func (c *oauth2ClientCredentials) Authenticate(r *http.Request) error {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+	if c.tokenSource != nil {
+		token, err := c.tokenSource.Token()
+		if err != nil {
+			return err
+		}
+		token.SetAuthHeader(r)
+		return nil
+	}
+
+	config := clientcredentials.Config{
+		ClientID:     c.clientID,
+		ClientSecret: c.clientSecret,
+		TokenURL:     c.tokenUrl,
+	}
+
+	// Create context with 1m timeout to cancel token fetching
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	if cancel != nil {
+		log.DefaultLogger.Debug("ignoring defer for timeout to not cancel original request")
+	}
+
+	c.tokenSource = config.TokenSource(ctx)
+
+	log.DefaultLogger.Debug("token fetching started")
+	token, err := c.tokenSource.Token()
+
+	if err != nil {
+		log.DefaultLogger.Error("token fetching failed", "err", err)
+		return err
+	} else {
+		log.DefaultLogger.Debug("token fetched successfully")
+	}
+	token.SetAuthHeader(r)
+
+	return nil
+
+}
+
+func NewOauth2ClientCredentials(clientID, clientSecret, tokenUrl string) auth.Authenticator {
+	return &oauth2ClientCredentials{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		tokenUrl:     tokenUrl,
+		tokenSource:  nil,
+		mx:           sync.Mutex{},
+	}
+}

--- a/src/components/ConfigEditor/ConfigEditor.tsx
+++ b/src/components/ConfigEditor/ConfigEditor.tsx
@@ -129,6 +129,17 @@ export class ConfigEditor extends PureComponent<Props, State> {
     });
   }
 
+  onExternalCredentialsUrlChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { onOptionsChange, options } = this.props;
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        externalCredentialsUrl: event.target.value,
+      },
+    });
+  };
+
   render() {
     const { options } = this.props;
     const { secureJsonFields } = options;
@@ -162,7 +173,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
                   onChange={this.onPathChange}
               />
             </InlineField>
-            <InlineField label="Authentication Method" labelWidth={30} tooltip="PAT (Personal Access Token) or M2M (Machine to Machine) OAuth Authentication">
+            <InlineField label="Authentication Method" labelWidth={30} tooltip="PAT (Personal Access Token), M2M (Machine to Machine) OAuth or OAuth 2.0 Client Credentials (not Databricks M2M) Authentication">
               <Select
                   onChange={({ value }) => {
                     this.onAuthenticationMethodChange(value);
@@ -176,12 +187,26 @@ export class ConfigEditor extends PureComponent<Props, State> {
                       value: 'm2m',
                       label: 'M2M Oauth',
                     },
+                    {
+                      value: 'oauth2_client_credentials',
+                      label: 'OAuth2 Client Credentials',
+                    },
                   ]}
                   value={jsonData.authenticationMethod || 'dsn'}
                   backspaceRemovesValue
               />
             </InlineField>
-            {jsonData.authenticationMethod === 'm2m' ? (
+            {jsonData.authenticationMethod === 'oauth2_client_credentials' && (
+              <InlineField label="OAuth2 Token Endpoint" labelWidth={30} tooltip="HTTP URL to token endpoint">
+                <Input
+                    value={jsonData.externalCredentialsUrl || ''}
+                    placeholder="http://localhost:2020"
+                    width={40}
+                    onChange={this.onExternalCredentialsUrlChange}
+                />
+              </InlineField>
+            )}
+            {(jsonData.authenticationMethod === 'm2m' || jsonData.authenticationMethod === 'oauth2_client_credentials') ? (
                 <>
                   <InlineField label="Client ID" labelWidth={30} tooltip="Databricks Service Principal Client ID">
                     <Input

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export interface MyDataSourceOptions extends DataSourceJsonData {
   autoCompletion?: boolean;
   authenticationMethod?: string;
   clientId?: string;
+  externalCredentialsUrl?: string;
 }
 
 /**


### PR DESCRIPTION
- Adds support for OAuth2 Client Credentials Grant - can be used to use external HTTP endpoint for pulling Databricks credentials (instead of using fixed PAT token). 