### PR TITLE
:bug: Fix: use Invalid Session Handle retry logic for Code Auto Completion Queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 1.2.7
+## 1.2.8
+
+- Bugfix: Use retry logic on Invalid SessionHandle error for Code Autocomplete Suggestions Queries
+
+---
+
+### 1.2.7
 
 - Feature: Add support to fetch Databricks Token from external OAuth Endpoint 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mullerpeter-databricks-datasource",
   "private": true,
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Databricks SQL Connector",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -187,7 +187,7 @@ type Datasource struct {
 }
 
 func (d *Datasource) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
-	return autocompletionQueries(req, sender, d.databricksDB)
+	return autocompletionQueries(req, sender, d)
 }
 
 // Dispose here tells plugin SDK that plugin wants to clean up resources when a new instance


### PR DESCRIPTION
- Extend the Code Auto Completion Queries to make use of the same retry logic on Invalid SessionHandle Errors

Potentialy relates to #73 