### PR TITLE
:memo: Doc: increase min grafana 7 version for v1.1.7 build in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For the latest version of the plugin the following requirements need to be met:
 - Grafana Version >= 10.4.1
 
 If you are using an earlier Grafana version try one of the following Plugin Versions:
-- [v1.1.7](https://github.com/mullerpeter/databricks-grafana/releases/tag/v1.1.7) (Supports Grafana Version >= 7.0)
+- [v1.1.7](https://github.com/mullerpeter/databricks-grafana/releases/tag/v1.1.7) (Supports Grafana Version >= 7.4.0)
 - [v1.2.9](https://github.com/mullerpeter/databricks-grafana/releases/tag/v1.2.9) (Supports Grafana Version >= 9.1.0)
 
 #### Install the Data Source

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ For the latest version of the plugin the following requirements need to be met:
 - Grafana Version >= 10.4.1
 
 If you are using an earlier Grafana version try one of the following Plugin Versions:
-- [v1.1.7](https://github.com/mullerpeter/databricks-grafana/releases/tag/v1.1.7) (Supports Grafana Version >= 7.0)
+- [v1.1.7](https://github.com/mullerpeter/databricks-grafana/releases/tag/v1.1.7) (Supports Grafana Version >= 7.4.0)
 - [v1.2.9](https://github.com/mullerpeter/databricks-grafana/releases/tag/v1.2.9) (Supports Grafana Version >= 9.1.0)
 
 #### Install the Data Source


### PR DESCRIPTION
- Code Editor Component from grafana/ui is broken upto Version Grafana 7.4.0
- Increase minimum version in Readme vor the older v1.1.7 build

Related to #107 