### PR TITLE
:recycle: Refactor: Rename Azure entra pass-through Auth Methof to OAuth pass-through & bugfix for CallResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To configure the plugin use the values provided under JDBC/ODBC in the advanced 
 - [Personal Access Token (PAT)](https://docs.databricks.com/en/dev-tools/auth/pat.html)
 - [Databricks M2M OAuth](https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html) using a Service Principal Client ID and Client Secret
 - External OAuth Client Credential Endpoint which returns a Databricks token (the OAuth endpoint should implement the default [OAuth Client Credential Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4)) i.e. Azure Entra (OAuth2 Endpoint `https://login.microsoftonline.com/{tenant-id}/oauth2/v2.0/token` & Scope `2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default`)
-- Azure Entra Pass Thru, which uses the Entra Auth token from the signed in user (IMPORTANT: `2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default` has to be added to the scopes of the Entra Auth configuration in Grafana!). Additionally the plugin won't work with this option selected if the user is not signed in via Azure Entra SSO and for backend Grafana Tasks (e.g.Alerting).
+- OAuth2 pass-trough, which forwards the Grafana SSO OAuth (i.e. Azure AD/Entra) token from the signed-in user to the plugin. Make sure to set the correct scope in the SSO OAuth configuration of Grafana for your Auth provider. i.E. for Azure AD/Entra SSO Auth the scope `2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default` (AzureDatabricks/user_impersonation) has to be added to the scopes of the Auth configuration in Grafana! Additionally, the plugin won't work with this option selected if the user is not signed in SSO and for backend Grafana Tasks (e.g.Alerting).
 
 ![img_1.png](img/config_editor.png)
 
@@ -80,7 +80,7 @@ Available configuration fields are as follows:
 | Server Hostname        | Databricks Server Hostname (without http). i.e. `XXX.cloud.databricks.com`                                                                                                   |
 | Server Port            | Databricks Server Port (default `443`)                                                                                                                                       |
 | HTTP Path              | HTTP Path value for the existing cluster or SQL warehouse. i.e. `sql/1.0/endpoints/XXX`                                                                                      |
-| Authentication Method  | PAT (Personal Access Token), M2M (Machine to Machine) OAuth, OAuth2 Client Credentials Authentication or Azure Entra Pass Thru                                               |
+| Authentication Method  | PAT (Personal Access Token), M2M (Machine to Machine) OAuth, OAuth2 Client Credentials Authentication or OAuth pass-through                                                  |
 | Client ID              | Databricks Service Principal Client ID. (only if OAuth / OAuth2 is chosen as Auth Method)                                                                                    |
 | Client Secret          | Databricks Service Principal Client Secret. (only if OAuth / OAuth2 is chosen as Auth Method)                                                                                |
 | Access Token           | Personal Access Token for Databricks. (only if PAT is chosen as Auth Method)                                                                                                 |
@@ -113,7 +113,7 @@ datasources:
       hostname: XXX.cloud.databricks.com
       httpPath: sql/1.0/endpoints/XXX
       port: 443
-      authenticationMethod: dsn (=PAT) | m2m | oauth2_client_credentials | azure_entra_pass_thru
+      authenticationMethod: dsn (=PAT) | m2m | oauth2_client_credentials | oauth2_pass_through
       clientId: ...
       externalCredentialsUrl: ...
       oauthScopes: api,read

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ To configure the plugin use the values provided under JDBC/ODBC in the advanced 
 - [Personal Access Token (PAT)](https://docs.databricks.com/en/dev-tools/auth/pat.html)
 - [Databricks M2M OAuth](https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html) using a Service Principal Client ID and Client Secret
 - External OAuth Client Credential Endpoint which returns a Databricks token (the OAuth endpoint should implement the default [OAuth Client Credential Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4)) i.e. Azure Entra (OAuth2 Endpoint `https://login.microsoftonline.com/{tenant-id}/oauth2/v2.0/token` & Scope `2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default`)
-- Azure Entra Pass Thru, which uses the Entra Auth token from the signed in user (IMPORTANT: `2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default` has to be added to the scopes of the Entra Auth configuration in Grafana!). Additionally the plugin won't work with this option selected if the user is not signed in via Azure Entra SSO and for backend Grafana Tasks (e.g.Alerting).
+- OAuth2 pass-trough, which forwards the Grafana SSO OAuth (i.e. Azure AD/Entra) token from the signed-in user to the plugin. Make sure to set the correct scope in the SSO OAuth configuration of Grafana for your Auth provider. i.E. for Azure AD/Entra SSO Auth the scope `2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default` (AzureDatabricks/user_impersonation) has to be added to the scopes of the Auth configuration in Grafana! Additionally, the plugin won't work with this option selected if the user is not signed in SSO and for backend Grafana Tasks (e.g.Alerting).
 
 ![img_1.png](img/config_editor.png)
 
@@ -80,7 +80,7 @@ Available configuration fields are as follows:
 | Server Hostname        | Databricks Server Hostname (without http). i.e. `XXX.cloud.databricks.com`                                                                                                   |
 | Server Port            | Databricks Server Port (default `443`)                                                                                                                                       |
 | HTTP Path              | HTTP Path value for the existing cluster or SQL warehouse. i.e. `sql/1.0/endpoints/XXX`                                                                                      |
-| Authentication Method  | PAT (Personal Access Token), M2M (Machine to Machine) OAuth, OAuth2 Client Credentials Authentication or Azure Entra Pass Thru                                               |
+| Authentication Method  | PAT (Personal Access Token), M2M (Machine to Machine) OAuth, OAuth2 Client Credentials Authentication or OAuth2 pass-through                                                 |
 | Client ID              | Databricks Service Principal Client ID. (only if OAuth / OAuth2 is chosen as Auth Method)                                                                                    |
 | Client Secret          | Databricks Service Principal Client Secret. (only if OAuth / OAuth2 is chosen as Auth Method)                                                                                |
 | Access Token           | Personal Access Token for Databricks. (only if PAT is chosen as Auth Method)                                                                                                 |
@@ -106,32 +106,32 @@ The Datasource configuration can also be done via a YAML file as described [here
 
 ```yaml
 datasources:
-   - name: Databricks
-     type: mullerpeter-databricks-datasource
-     isDefault: true
-     jsonData:
-        hostname: XXX.cloud.databricks.com
-        httpPath: sql/1.0/endpoints/XXX
-        port: 443
-        authenticationMethod: dsn (=PAT) | m2m | oauth2_client_credentials | azure_entra_pass_thru
-        clientId: ...
-        externalCredentialsUrl: ...
-        oauthScopes: api,read
-        timeInterval: 1m
-        maxOpenConns: 0
-        maxIdleConns: 0
-        connMaxLifetime: 3600
-        connMaxIdleTime: 3600
-        retries: 3
-        retryBackoff: 1
-        maxRetryDuration: 60
-        timeout: 60
-        maxRows: 10000
-        defaultQueryFormat: table | time_series
-        defaultEditorMode: builder | code
-     secureJsonData:
-        clientSecret: ...
-        token: ...
+  - name: Databricks
+    type: mullerpeter-databricks-datasource
+    isDefault: true
+    jsonData:
+      hostname: XXX.cloud.databricks.com
+      httpPath: sql/1.0/endpoints/XXX
+      port: 443
+      authenticationMethod: dsn (=PAT) | m2m | oauth2_client_credentials | oauth2_pass_through
+      clientId: ...
+      externalCredentialsUrl: ...
+      oauthScopes: api,read
+      timeInterval: 1m
+      maxOpenConns: 0
+      maxIdleConns: 0
+      connMaxLifetime: 3600
+      connMaxIdleTime: 3600
+      retries: 3
+      retryBackoff: 1
+      maxRetryDuration: 60
+      timeout: 60
+      maxRows: 10000
+      defaultQueryFormat: table | time_series
+      defaultEditorMode: builder | code
+    secureJsonData:
+      clientSecret: ...
+      token: ...
 ```
 ### Supported Macros
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mullerpeter-databricks-datasource",
   "private": true,
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Databricks SQL Connector",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/integrations/oauth_pass_trough.go
+++ b/pkg/integrations/oauth_pass_trough.go
@@ -27,15 +27,15 @@ func (ts *TokenStorage) Update(newToken string) {
 	ts.token = newToken
 }
 
-type Authenticator struct {
+type OAuthPassThroughAuthenticator struct {
 	tokenStorage *TokenStorage
 }
 
-func NewAuthenticator(ts *TokenStorage) *Authenticator {
-	return &Authenticator{tokenStorage: ts}
+func NewOAuthPassThroughAuthenticator(ts *TokenStorage) *OAuthPassThroughAuthenticator {
+	return &OAuthPassThroughAuthenticator{tokenStorage: ts}
 }
 
-func (a *Authenticator) Authenticate(r *http.Request) error {
+func (a *OAuthPassThroughAuthenticator) Authenticate(r *http.Request) error {
 	if a.tokenStorage.Get() == "" {
 		return fmt.Errorf("Empty Token Pass Trough")
 	}

--- a/src/components/ConfigEditor/ConfigEditor.tsx
+++ b/src/components/ConfigEditor/ConfigEditor.tsx
@@ -35,10 +35,17 @@ export class ConfigEditor extends PureComponent<Props, State> {
             ...jsonData,
             [key]: value
         }
-        if (key == 'authenticationMethod' && value == 'azure_entra_pass_thru') {
-            jsonData = {
-                ...jsonData,
-                oauthPassThru: true,
+        if (key == 'authenticationMethod') {
+            if (value == 'oauth2_pass_through') {
+                jsonData = {
+                    ...jsonData,
+                    oauthPassThru: true,
+                }
+            } else {
+                jsonData = {
+                    ...jsonData,
+                    oauthPassThru: false,
+                }
             }
         }
         onOptionsChange({
@@ -127,8 +134,8 @@ export class ConfigEditor extends PureComponent<Props, State> {
                                     label: 'OAuth2 Client Credentials',
                                 },
                                 {
-                                    value: 'azure_entra_pass_thru',
-                                    label: 'Pass Thru Azure Entra Auth',
+                                    value: 'oauth2_pass_through',
+                                    label: 'OAuth2 pass-through',
                                 },
                             ]}
                             value={jsonData.authenticationMethod || 'dsn'}
@@ -178,7 +185,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
                                 />
                             </InlineField>
                         </>
-                    ) : jsonData.authenticationMethod != 'azure_entra_pass_thru' && (
+                    ) : jsonData.authenticationMethod != 'oauth2_pass_through' && (
                         <InlineField label="Access Token" labelWidth={30} tooltip="Databricks Personal Access Token">
                             <SecretInput
                                 isConfigured={(secureJsonFields && secureJsonFields.token) as boolean}
@@ -190,10 +197,11 @@ export class ConfigEditor extends PureComponent<Props, State> {
                             />
                         </InlineField>
                     )}
-                    {jsonData.authenticationMethod === 'azure_entra_pass_thru' && (
-                        <Alert title="Pass Thru Azure Entra Auth" severity="info">
-                            <p>Pass Thru Azure Entra Auth only works if Azure Entra Auth is setup in Grafana and the user is signed in via Azure Entra SSO. (i.e. Alerts and other backend tasks won't work)</p>
-                            <p>Make sure to set the correct permissions for the Databricks workspace and the SQL warehouse. And add the following Databricks Scope in the Grafana Azure Entra Auth Configuration Settings: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default"</p>
+                    {jsonData.authenticationMethod === 'oauth2_pass_through' && (
+                        <Alert title="OAuth2 pass-trough" severity="info">
+                            <p>OAuth2 pass-trough only works if SSO Auth (i.e. Azure AD/Entra) is setup in Grafana and the user is signed in via SSO. (i.e. Alerts and other backend tasks won't work)</p>
+                            <p>Make sure to set the correct permissions for the Databricks workspace and the SQL warehouse and add the correct scope in the Grafana Authentication Settings for you SSO Auth Provider.</p>
+                            <p>i.E. for Azure AD/Entra SSO Auth the following scope has to be added: "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default" (AzureDatabricks/user_impersonation)</p>
                         </Alert>
                     )}
                     <hr/>


### PR DESCRIPTION
- Refactor/Rename `Azure Entra pass-through` Auth Method to `OAuth2 pass-through`, as this can be used with any OAuth SSO provider in Grafana not just Entra.
- Bugfix: Add pass-through Token check to `CallResource` so that Auto Complete Queries with OAuth pass-through work correctly